### PR TITLE
Forget password

### DIFF
--- a/routes/forget.js
+++ b/routes/forget.js
@@ -31,6 +31,15 @@ forgetPath = function(request, response)
                     }
                 });
             }
+            else // body.ackValue = "FAILURE"
+            {
+                response.render("login", {
+                    message : {
+                        type: "danger",
+                        content: body.errors[0].errorMessage
+                    }
+                });
+            }
         });
 
     }

--- a/routes/forget.js
+++ b/routes/forget.js
@@ -1,9 +1,21 @@
+var validate = require("./validate");
+
 forgetPath = function(request, response)
 {
+    var content;
+    if(validate.isEmail(request.body.email))
+    {
+        content = "You seem to have forgotten your password\nWhy don't you check your email at: " + request.body.email
+    }
+    else
+    {
+        content = "That's not a valid email";
+    }
+
     response.render("login", {
         message : {
             type: "warning",
-            content: "You seem to have forgotten your password"
+            content: content
         }
     });
 }

--- a/routes/forget.js
+++ b/routes/forget.js
@@ -1,16 +1,38 @@
 var validate = require("./validate");
+var request_api = require('request');
 
 forgetPath = function(request, response)
 {
     var content;
     if(validate.isEmail(request.body.email))
     {
-        response.render("login", {
-            message : {
-                type: "info",
-                content: "An reset email has been sent to \n " + request.body.email
+        var options = {
+            url: "https://tenv-service.swiftceipt.com/forgotPassword",
+            headers:
+            {
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            },
+            json: true,
+            body: 
+            {
+                "email": request.body.email
+            }
+        }
+
+        request_api.post(options, function(error, api_response, body)
+        {
+            if(body.ackValue == "SUCCESS")
+            {
+                response.render("login", {
+                    message : {
+                        type: "info",
+                        content: "A reset email has been sent to \n " + request.body.email
+                    }
+                });
             }
         });
+
     }
     else
     {

--- a/routes/forget.js
+++ b/routes/forget.js
@@ -26,7 +26,7 @@ forgetPath = function(request, response)
             {
                 response.render("login", {
                     message : {
-                        type: "info",
+                        type: "success",
                         content: "A reset email has been sent to \n " + request.body.email
                     }
                 });

--- a/routes/forget.js
+++ b/routes/forget.js
@@ -1,0 +1,13 @@
+forgetPath = function(request, response)
+{
+    response.render("login", {
+        message : {
+            type: "warning",
+            content: "You seem to have forgotten your password"
+        }
+    });
+}
+
+module.exports = {
+    forgetPath: forgetPath
+}

--- a/routes/forget.js
+++ b/routes/forget.js
@@ -5,19 +5,23 @@ forgetPath = function(request, response)
     var content;
     if(validate.isEmail(request.body.email))
     {
-        content = "You seem to have forgotten your password\nWhy don't you check your email at: " + request.body.email
+        response.render("login", {
+            message : {
+                type: "info",
+                content: "An reset email has been sent to \n " + request.body.email
+            }
+        });
     }
     else
     {
-        content = "That's not a valid email";
+        response.render("login", {
+            message : {
+                type: "warning",
+                content: "That's not a valid email"
+            }
+        });
     }
 
-    response.render("login", {
-        message : {
-            type: "warning",
-            content: content
-        }
-    });
 }
 
 module.exports = {

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -1,5 +1,6 @@
 var request_api = require('request');
 var validation = require('./validate');
+var forget = require('./forget');
 
 exports.init = function(app)
 {
@@ -10,6 +11,8 @@ exports.init = function(app)
     });
     app.post("/login", check_login);
     app.get("/logout", is_logged_in, logout);
+
+    app.post("/forget", forget.forgetPath);
 
     app.get("/register", register_landing);
     app.post("/register", register);

--- a/routes/validate.js
+++ b/routes/validate.js
@@ -59,5 +59,6 @@ new_user = function(body)
 }
 
 module.exports = {
-    new_user: new_user
+    new_user: new_user,
+    isEmail: isEmail
 };

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -50,10 +50,10 @@
                     <div class="modal-dialog" role="document">
                         <div class="modal-content">
                             <div class="modal-body">
-                                <form action = "#" method = "get">
+                                <form action = "/forget" method = "post">
                                     <div class="form-group">
                                         <label for="recipient-name" class="control-label">Enter Your Email:</label>
-                                        <input type="text" class="form-control" id="recipient-name">
+                                        <input type="text" class="form-control" id="recipient-name" name = "email">
                                     </div>
                                 </form>
                             </div>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -7,6 +7,9 @@
 <html lang="en">
     <head>
         <% include partials/headers %>
+        <script type="text/javascript">
+                $('#forgetModal').on('shown.bs.modal', function () { $('#myInput').focus()})
+        </script>
         <title>Login</title>
     </head>
 
@@ -29,6 +32,29 @@
 
                 <br />
                 <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+
+                <button type="button" class="btn btn-default btn-block" data-toggle = "modal" data-target="#forgetModal">
+                    Forgot Password ?
+                </button>
+
+                <div class="modal fade" id="forgetModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-body">
+                                <form action = "#" method = "post">
+                                    <div class="form-group">
+                                        <label for="recipient-name" class="control-label">Enter Your Email:</label>
+                                        <input type="text" class="form-control" id="recipient-name">
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                <button type="button" class="btn btn-primary">Submit Reset Request</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <br />
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -37,11 +37,20 @@
                     Forgot Password ?
                 </button>
 
+                <br />
+
+                <% if (typeof message != 'undefined') { %>
+                    <div class="alert alert-<%= message.type %>" role = "alert">
+                        <%= message.content %>
+                    </div>
+                <% } %>
+            </form>
+
                 <div class="modal fade" id="forgetModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
                     <div class="modal-dialog" role="document">
                         <div class="modal-content">
                             <div class="modal-body">
-                                <form action = "#" method = "post">
+                                <form action = "#" method = "get">
                                     <div class="form-group">
                                         <label for="recipient-name" class="control-label">Enter Your Email:</label>
                                         <input type="text" class="form-control" id="recipient-name">
@@ -56,15 +65,6 @@
                     </div>
                 </div>
 
-                <br />
-
-                <% if (typeof message != 'undefined') { %>
-                    <div class="alert alert-<%= message.type %>" role = "alert">
-                        <%= message.content %>
-                    </div>
-                <% } %>
-
-            </form>
         </div> <!-- /container -->
          <br>
         <br>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -49,18 +49,18 @@
                 <div class="modal fade" id="forgetModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
                     <div class="modal-dialog" role="document">
                         <div class="modal-content">
-                            <div class="modal-body">
-                                <form action = "/forget" method = "post">
-                                    <div class="form-group">
-                                        <label for="recipient-name" class="control-label">Enter Your Email:</label>
-                                        <input type="text" class="form-control" id="recipient-name" name = "email">
-                                    </div>
-                                </form>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                <button type="button" class="btn btn-primary">Submit Reset Request</button>
-                            </div>
+                            <form action = "/forget" method = "post">
+                                <div class="modal-body">
+                                        <div class="form-group">
+                                            <label for="recipient-name" class="control-label">Enter Your Email:</label>
+                                            <input type="text" class="form-control" id="recipient-name" name = "email">
+                                        </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button class="btn btn-lg btn-primary btn-block" type = "submit">Submit Reset Request</button>
+                                    <button class="btn btn-default btn-block" data-dismiss="modal">Close</button>
+                                </div>
+                            </form>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Users now have the ability to request a reset email on the login page should they forget their password.

I made the following changes:

`routes/routes.js`
- Linked to a new module to avoid cluttering this file

`routes/forget.js`
- Added all the logic surrounding calling the `/forgotPassword` endpoint that SC provides
- Renders error and success messages appropriately

`routes/validate.js`
- exported `isEmail` to use in `routes/forget.js`

`views/login.ejs`
- Create pop-up window to use when forgetting your password